### PR TITLE
Remove ptl interrupted

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,3 +1,15 @@
+==========================
+Mon Oct 16 13:05:34 2023
+
+Removing PTL_INTERRUPTED error code (deprecated as of 4.3)
+
+==========================
+
+Fix mdrelease when ptl_no_space happens
+
+==========================
+
+
 Shared Memory Unimplemented Features:
 
 - Ptl{LE,ME}Append() does not work with persistent LEs and buffered headers
@@ -18,11 +30,3 @@ Infiniband Informal list of known issues/bugs:
 ----	----------	----------	---------------------------------------------------
 1000	2011/04/14	open		PtlPTDisable busywaits, should use a cond variable
 1001	2011/04/14	2011/04/14	pt_h doesn't need to contain an object, fixed.
-
-
-
-
-
-==========================
-
-Fix mdrelease when ptl_no_space happens

--- a/include/portals4.h
+++ b/include/portals4.h
@@ -27,7 +27,6 @@ enum ptl_retvals {
     PTL_FAIL,            /*!< Indicates a non-specific error */
     PTL_IGNORED,         /*!< Logical map set failed. */
     PTL_IN_USE,          /*!< The specified resource is currently in use. */
-    PTL_INTERRUPTED,     /*!< Wait/get operation was interrupted. */
     PTL_LIST_TOO_LONG,   /*!< The resulting list is too long (interface-dependent). */
     PTL_NO_INIT,         /*!< Init has not yet completed successfully. */
     PTL_NO_SPACE,        /*!< Sufficient memory for action was not available. */
@@ -35,6 +34,9 @@ enum ptl_retvals {
     PTL_PT_FULL,         /*!< Portal table has no empty entries. */
     PTL_PT_EQ_NEEDED,    /*!< Flow control is enabled and there is no EQ provided. */
     PTL_PT_IN_USE        /*!< Portal table index is busy. */
+    
+    /* Deprecated return vals */
+    //PTL_INTERRUPTED,     /*!< Wait/get operation was interrupted. */
 };
 #define PTL_STATUS_LAST (PTL_PT_IN_USE + 1)
 
@@ -1784,7 +1786,7 @@ int PtlCTCancelTriggered(ptl_handle_ct_t ct_handle);
  *                          successfully initialized.
  * @retval PTL_ARG_INVALID  Indicates that \a ct_handle is not a valid
  *                          counting event handle.
- * @retval PTL_INTERRUPTED  Indicates that PtlCTFree() or PtlNIFini() was
+ * @retval DEPRECATED PTL_INTERRUPTED  Indicates that PtlCTFree() or PtlNIFini() was
  *                          called by another thread while this thread was
  *                          in PtlCTGet()
  * @note PtlCTGet() must be as close to the speed of a simple variable
@@ -1813,14 +1815,14 @@ int PtlCTGet(ptl_handle_ct_t ct_handle,
  *                          successfully initialized.
  * @retval PTL_ARG_INVALID  Indicates that \a ct_handle is not a valid
  *                          counting event handle.
- * @retval PTL_INTERRUPTED  Indicates that PtlCTFree() or PtlNIFini() was
+ * @retval DEPRECATED PTL_INTERRUPTED  Indicates that PtlCTFree() or PtlNIFini() was
  *                          called by another thread while this thread was
  *                          waiting in PtlCTWait()
  * @note PtlCTWait() returns when the counting event referenced by the \a
  *      ct_handle is greater than or equal to the test; thus, the actual value
  *      of the counting event is returned to prevent the user from having to
  *      call PtlCTGet().
- * @implnote The return code of \c PTL_INTERRUPTED adds an unfortunate degree
+ * @implnote The return code of \c PTL_INTERRUPTED (DEPRECATED as of 4.3) adds an unfortunate degree
  *      of complexity to the PtlCTWait() function; however, it was deemed
  *      necessary to be able to interrupt waiting functions for the sake of
  *      applications that need to tolerate failures. Hence, this approach to
@@ -1878,7 +1880,7 @@ int PtlCTWait(ptl_handle_ct_t ct_handle,
  * @retval PTL_CT_NONE_REACHED  Indicates that none of the counting events
  *                              reached their test before the timeout was
  *                              reached.
- * @retval PTL_INTERRUPTED      Indicates that PtlCTFree() or PtlNIFini() was
+ * @retval DEPRECATED PTL_INTERRUPTED      Indicates that PtlCTFree() or PtlNIFini() was
  *                              called by another thread while this thread was
  *                              waiting in PtlCTPoll().
  * @implnote Implementations are discouraged from providing macros for
@@ -1886,7 +1888,7 @@ int PtlCTWait(ptl_handle_ct_t ct_handle,
  *      these functions. The usage scenario for PtlCTGet() and PtlCTWait() is
  *      expected to depend on minimizing the computational cost of these
  *      routines.
- * @implnote The return code of \c PTL_INTERRUPTED adds an unfortunate degree
+ * @implnote The return code of \c PTL_INTERRUPTED (DEPRECATED as of 4.3) adds an unfortunate degree
  *      of complexity to the PtlCTPoll() function; however, it was deemed
  *      necessary to be able to interrupt waiting functions for the sake of
  *      applications that need to tolerate failures. Hence, this approach to
@@ -2838,7 +2840,7 @@ int PtlEQFree(ptl_handle_eq_t eq_handle);
  *                          PtlEQWait(), or PtlEQPoll() -- from this event
  *                          queue has been dropped due to limited space in the
  *                          event queue.
- * @implnote The return code of \c PTL_INTERRUPTED adds an unfortunate degree of
+ * @implnote The return code of \c PTL_INTERRUPTED (DEPRECATED as of 4.3) adds an unfortunate degree of
  *      complexity to the PtlEQGet(), PtlEQWait(), and PtlEQPoll() functions;
  *      however, it was deemed necessary to be able to interrupt waiting
  *      functions for the sake of applications that need to tolerate failures.
@@ -2875,7 +2877,7 @@ int PtlEQGet(ptl_handle_eq_t eq_handle,
  *                              PtlEQGet(), PtlEQWait(), or PtlEQPoll() -- from
  *                              this event queue has been dropped due to
  *                              limited space in the event queue.
- * @retval PTL_INTERRUPTED      Indicates that PtlEQFree() or PtlNIFini() was
+ * @retval DEPRECATED PTL_INTERRUPTED      Indicates that PtlEQFree() or PtlNIFini() was
  *                              called by another thread while this thread was
  *                              waiting in PtlEQWait().
  * @see PtlEQGet(), PtlEQPoll()
@@ -2927,7 +2929,7 @@ int PtlEQWait(ptl_handle_eq_t eq_handle,
  *                              and the last event obtained from the event
  *                              queue indicated by \a which has been dropped
  *                              due to limited space in the event queue.
- * @retval PTL_INTERRUPTED      Indicates that PtlEQFree() or PtlNIFini() was
+ * @retval DEPRECATED PTL_INTERRUPTED      Indicates that PtlEQFree() or PtlNIFini() was
  *                              called by another thread while this thread was
  *                              waiting in PtlEQPoll().
  * @implnote Implementations are free to provide macros for PtlEQGet() and

--- a/include/portals4.h
+++ b/include/portals4.h
@@ -36,7 +36,7 @@ enum ptl_retvals {
     PTL_PT_IN_USE        /*!< Portal table index is busy. */
     
     /* Deprecated return vals */
-    //PTL_INTERRUPTED,     /*!< Wait/get operation was interrupted. */
+    //PTL_INTERRUPTED,     /*!< Wait/get operation was interrupted. Deprecated as of 4.3. */
 };
 #define PTL_STATUS_LAST (PTL_PT_IN_USE + 1)
 
@@ -1786,9 +1786,6 @@ int PtlCTCancelTriggered(ptl_handle_ct_t ct_handle);
  *                          successfully initialized.
  * @retval PTL_ARG_INVALID  Indicates that \a ct_handle is not a valid
  *                          counting event handle.
- * @retval DEPRECATED PTL_INTERRUPTED  Indicates that PtlCTFree() or PtlNIFini() was
- *                          called by another thread while this thread was
- *                          in PtlCTGet()
  * @note PtlCTGet() must be as close to the speed of a simple variable
  *      access as possible; hence, PtlCTGet() is not atomic relative to
  *      PtlCTSet() or PtlCTInc() and is undefined if PtlCTFree() or PtlNIFini()
@@ -1815,18 +1812,10 @@ int PtlCTGet(ptl_handle_ct_t ct_handle,
  *                          successfully initialized.
  * @retval PTL_ARG_INVALID  Indicates that \a ct_handle is not a valid
  *                          counting event handle.
- * @retval DEPRECATED PTL_INTERRUPTED  Indicates that PtlCTFree() or PtlNIFini() was
- *                          called by another thread while this thread was
- *                          waiting in PtlCTWait()
  * @note PtlCTWait() returns when the counting event referenced by the \a
  *      ct_handle is greater than or equal to the test; thus, the actual value
  *      of the counting event is returned to prevent the user from having to
  *      call PtlCTGet().
- * @implnote The return code of \c PTL_INTERRUPTED (DEPRECATED as of 4.3) adds an unfortunate degree
- *      of complexity to the PtlCTWait() function; however, it was deemed
- *      necessary to be able to interrupt waiting functions for the sake of
- *      applications that need to tolerate failures. Hence, this approach to
- *      dealing with the conflict of reading and freeing events was chosen.
  * @see PtlCTGet(), PtlCTPoll()
  */
 int PtlCTWait(ptl_handle_ct_t ct_handle,
@@ -1880,20 +1869,11 @@ int PtlCTWait(ptl_handle_ct_t ct_handle,
  * @retval PTL_CT_NONE_REACHED  Indicates that none of the counting events
  *                              reached their test before the timeout was
  *                              reached.
- * @retval DEPRECATED PTL_INTERRUPTED      Indicates that PtlCTFree() or PtlNIFini() was
- *                              called by another thread while this thread was
- *                              waiting in PtlCTPoll().
  * @implnote Implementations are discouraged from providing macros for
  *      PtlCTGet() and PtlCTWait() that use PtlCTPoll() instead of providing
  *      these functions. The usage scenario for PtlCTGet() and PtlCTWait() is
  *      expected to depend on minimizing the computational cost of these
  *      routines.
- * @implnote The return code of \c PTL_INTERRUPTED (DEPRECATED as of 4.3) adds an unfortunate degree
- *      of complexity to the PtlCTPoll() function; however, it was deemed
- *      necessary to be able to interrupt waiting functions for the sake of
- *      applications that need to tolerate failures. Hence, this approach to
- *      dealing with the conflict of reading and freeing events was chosen.
- * @see PtlCTWait(), PtlCTGet()
  */
 int PtlCTPoll(const ptl_handle_ct_t *ct_handles,
               const ptl_size_t      *tests,
@@ -2840,12 +2820,6 @@ int PtlEQFree(ptl_handle_eq_t eq_handle);
  *                          PtlEQWait(), or PtlEQPoll() -- from this event
  *                          queue has been dropped due to limited space in the
  *                          event queue.
- * @implnote The return code of \c PTL_INTERRUPTED (DEPRECATED as of 4.3) adds an unfortunate degree of
- *      complexity to the PtlEQGet(), PtlEQWait(), and PtlEQPoll() functions;
- *      however, it was deemed necessary to be able to interrupt waiting
- *      functions for the sake of applications that need to tolerate failures.
- *      Hence, this approach to dealing with the conflict of reading and
- *      freeing events was chosen.
  * @see PtlEQWait(), PtlEQPoll()
  */
 int PtlEQGet(ptl_handle_eq_t eq_handle,
@@ -2877,9 +2851,6 @@ int PtlEQGet(ptl_handle_eq_t eq_handle,
  *                              PtlEQGet(), PtlEQWait(), or PtlEQPoll() -- from
  *                              this event queue has been dropped due to
  *                              limited space in the event queue.
- * @retval DEPRECATED PTL_INTERRUPTED      Indicates that PtlEQFree() or PtlNIFini() was
- *                              called by another thread while this thread was
- *                              waiting in PtlEQWait().
  * @see PtlEQGet(), PtlEQPoll()
  */
 int PtlEQWait(ptl_handle_eq_t eq_handle,
@@ -2929,9 +2900,6 @@ int PtlEQWait(ptl_handle_eq_t eq_handle,
  *                              and the last event obtained from the event
  *                              queue indicated by \a which has been dropped
  *                              due to limited space in the event queue.
- * @retval DEPRECATED PTL_INTERRUPTED      Indicates that PtlEQFree() or PtlNIFini() was
- *                              called by another thread while this thread was
- *                              waiting in PtlEQPoll().
  * @implnote Implementations are free to provide macros for PtlEQGet() and
  *      PtlEQWait() that use PtlEQPoll() instead of providing these functions.
  * @implnote Not all of the members of the ptl_event_t structure (and

--- a/src/ib/ptl_ct.c
+++ b/src/ib/ptl_ct.c
@@ -352,9 +352,6 @@ int _PtlCTGet(PPEGBL ptl_handle_ct_t ct_handle, ptl_ct_event_t *event_p)
  * successfully initialized.
  * @return PTL_ARG_INVALID Indicates that ct_handle is not a valid
  * counting event handle.
- * @return PTL_INTERRUPTED Indicates that PtlCTFree() or PtlNIFini()
- * was called by another thread while this thread * was waiting in
- * PtlCTWait().
  */
 int _PtlCTWait(PPEGBL ptl_handle_ct_t ct_handle, uint64_t threshold,
                ptl_ct_event_t *event_p)
@@ -408,9 +405,6 @@ int _PtlCTWait(PPEGBL ptl_handle_ct_t ct_handle, uint64_t threshold,
  * bad ct_handle).
  * @return PTL_CT_NONE_REACHED Indicates that none of the counting
  * events reached their test before the timeout was * reached.
- * @return PTL_INTERRUPTED Indicates that PtlCTFree() or PtlNIFini()
- * was called by another thread while this thread * was waiting
- * in PtlCTPoll().
  */
 int _PtlCTPoll(PPEGBL const ptl_handle_ct_t *ct_handles,
                const ptl_size_t *thresholds, unsigned int size,

--- a/src/ib/ptl_ct_common.c
+++ b/src/ib/ptl_ct_common.c
@@ -32,7 +32,9 @@ int PtlCTWait_work(struct ct_info *ct_info, uint64_t threshold,
 
         /* someone called PtlCTFree or PtlNIFini, leave */
         if (unlikely(ct_info->interrupt)) {
-            err = PTL_INTERRUPTED;
+            /* PTL_INTERRUPTED is deprecated as of 4.3 */ 
+            //err = PTL_INTERRUPTED;
+            err = PTL_FAIL;
             break;
         }
 
@@ -54,9 +56,8 @@ int PtlCTWait_work(struct ct_info *ct_info, uint64_t threshold,
  * @param thresholds array of thresholds
  * @param event_p address of returned event
  * @param which_p address of returned which
- *
+ * 
  * @return PTL_OK if found an event
- * @return PTL_INTERRUPTED if someone is tearing down a ct
  * @return PTL_CT_NONE_REACHED if did not find an event
  */
 static int ct_poll_loop(int size, struct ct_info *cts_info[],
@@ -78,7 +79,9 @@ static int ct_poll_loop(int size, struct ct_info *cts_info[],
 
         if (ct_info->interrupt) {
             atomic_dec(&keep_polling);
-            return PTL_INTERRUPTED;
+            /* PTL_INTERRUPTED is deprecated as of 4.3 */
+            //return PTL_INTERRUPTED;
+            return PTL_FAIL;
         }
     }
 

--- a/src/ib/ptl_eq.c
+++ b/src/ib/ptl_eq.c
@@ -297,8 +297,6 @@ int _PtlEQGet(PPEGBL ptl_handle_eq_t eq_handle, ptl_event_t *event_p)
  * successfully initialized.
  * @return PTL_ARG_INVALID Indicates that eq_handle is not a valid event
  * queue handle.
- * @return PTL_INTERRUPTED Indicates that PtlEQFree() or PtlNIFini() was
- * called by another thread while this thread was waiting in PtlEQWait().
  */
 int _PtlEQWait(PPEGBL ptl_handle_eq_t eq_handle, ptl_event_t *event_p)
 {
@@ -353,8 +351,6 @@ int _PtlEQWait(PPEGBL ptl_handle_eq_t eq_handle, ptl_event_t *event_p)
  * The definition of which arguments are checked is implementation dependent.
  * @return PTL_EQ_EMPTY Indicates that the timeout has been reached and all
  * of the event queues are empty.
- * @return PTL_INTERRUPTED Indicates that PtlEQFree() or PtlNIFini() was
- * called by another thread while this thread was waiting in PtlEQPoll().
  */
 int _PtlEQPoll(PPEGBL const ptl_handle_eq_t * eq_handles, unsigned int size,
                ptl_time_t timeout, ptl_event_t *event_p,

--- a/src/ib/ptl_eq_common.c
+++ b/src/ib/ptl_eq_common.c
@@ -110,7 +110,9 @@ static inline int check_eq(struct eqe_list *eqe_list, ptl_event_t *event_p)
     }
 
     if (eqe_list->interrupt) {
-        return PTL_INTERRUPTED;
+        /* PTL_INTERRUPTED is deprecated as of 4.3 */
+        /* return PTL_INTERRUPTED; */
+        return PTL_FAIL;
     }
 
     return PTL_EQ_EMPTY;
@@ -176,7 +178,9 @@ int PtlEQPoll_work(struct eqe_list *eqe_list_in[], unsigned int size,
             }
 
             if (eqe_list->interrupt) {
-                err = PTL_INTERRUPTED;
+                /* PTL_INTERRUPTED is deprecated as of 4.3 */
+                /* err = PTL_INTERRUPTED; */
+                err = PTL_FAIL;
                 goto out;
             }
         }

--- a/test/sfw/enum.c
+++ b/test/sfw/enum.c
@@ -13,7 +13,7 @@ int get_ret(char *val)
 	else if (!strcmp("EQ_DROPPED", val))	return PTL_EQ_DROPPED;
 	else if (!strcmp("EQ_EMPTY", val))	return PTL_EQ_EMPTY;
 	else if (!strcmp("IN_USE", val))	return PTL_IN_USE;
-	else if (!strcmp("INTERRUPTED", val))	return PTL_INTERRUPTED;
+         //else if (!strcmp("INTERRUPTED", val))	return PTL_INTERRUPTED;
 	else if (!strcmp("LIST_TOO_LONG", val))	return PTL_LIST_TOO_LONG;
 	else if (!strcmp("NO_INIT", val))	return PTL_NO_INIT;
 	else if (!strcmp("NO_SPACE", val))	return PTL_NO_SPACE;

--- a/test/support.c
+++ b/test/support.c
@@ -55,8 +55,8 @@ char *libtest_StrPtlError(int error_code)
         case PTL_IGNORED:
             return "PTL_IGNORED";
 
-        case PTL_INTERRUPTED:
-            return "PTL_INTERRUPTED";
+        //case PTL_INTERRUPTED:
+        //    return "PTL_INTERRUPTED";
 
         case PTL_LIST_TOO_LONG:
             return "PTL_LIST_TOO_LONG";


### PR DESCRIPTION
Return code PTL_INTERRUPTED was deprecated as of 4.3.